### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,6 +23,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/sxpersxnic/atora/security/code-scanning/2](https://github.com/sxpersxnic/atora/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. For this workflow:
- The `build` job only needs read access to the repository contents.
- The `publish-npm` job requires read access to the repository contents and write access to packages for publishing to npm.

The `permissions` block can be added at the job level for each job (`build` and `publish-npm`) to ensure granular control.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
