### PR TITLE
Potential fix for code scanning alert no. 5: Disallow unused variables

### DIFF
--- a/src/components/navigation/link.tsx
+++ b/src/components/navigation/link.tsx
@@ -1,4 +1,3 @@
-import { is_external } from '../../../package/link/link';
 import { Element, Container } from '../../shared/types';
 
 interface Props extends Container {


### PR DESCRIPTION
Potential fix for [https://github.com/sxpersxnic/atora/security/code-scanning/5](https://github.com/sxpersxnic/atora/security/code-scanning/5)

To fix the problem, the unused `is_external` import should be removed from the file. This will eliminate the ESLint error and ensure the code adheres to best practices by avoiding unnecessary imports. No other changes are required, as the removal of this import does not affect the functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
